### PR TITLE
Fix empty reminders

### DIFF
--- a/src/roles.json
+++ b/src/roles.json
@@ -8,8 +8,10 @@
     "firstNightReminder": "Show the character token of a Townsfolk in play. Point to two players, one of which is that character.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Townsfolk",
-        "Wrong"],
+    "reminders": [
+      "Townsfolk",
+      "Wrong"
+    ],
     "setup": false,
     "ability": "You start knowing that 1 of 2 players is a particular Townsfolk."
   },
@@ -22,8 +24,10 @@
     "firstNightReminder": "Show the character token of an Outsider in play. Point to two players, one of which is that character.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Outsider",
-        "Wrong"],
+    "reminders": [
+      "Outsider",
+      "Wrong"
+    ],
     "setup": false,
     "ability": "You start knowing that 1 of 2 players is a particular Outsider. (Or that zero are in play.)"
   },
@@ -36,8 +40,10 @@
     "firstNightReminder": "Show the character token of a Minion in play. Point to two players, one of which is that character.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Minion",
-        "Wrong"],
+    "reminders": [
+      "Minion",
+      "Wrong"
+    ],
     "setup": false,
     "ability": "You start knowing that 1 of 2 players is a particular Minion."
   },
@@ -47,10 +53,10 @@
     "edition": "tb",
     "team": "townsfolk",
     "firstNight": 23,
-    "firstNightReminder": "Show the finger signal (0, 1, 2, \u2026) for the number of pairs of neighbouring evil players.",
+    "firstNightReminder": "Show the finger signal (0, 1, 2, …) for the number of pairs of neighbouring evil players.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "You start knowing how many pairs of evil players there are."
   },
@@ -63,7 +69,7 @@
     "firstNightReminder": "Show the finger signal (0, 1, 2) for the number of evil alive neighbours of the Empath.",
     "otherNight": 43,
     "otherNightReminder": "Show the finger signal (0, 1, 2) for the number of evil neighbours.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night, you learn how many of your 2 alive neighbours are evil."
   },
@@ -76,7 +82,9 @@
     "firstNightReminder": "The Fortune Teller points to two players. Give the head signal (nod yes, shake no) for whether one of those players is the Demon. ",
     "otherNight": 44,
     "otherNightReminder": "The Fortune Teller points to two players. Show the head signal (nod 'yes', shake 'no') for whether one of those players is the Demon.",
-    "reminders": ["Red herring"],
+    "reminders": [
+      "Red herring"
+    ],
     "setup": false,
     "ability": "Each night, choose 2 players: you learn if either is a Demon. There is a good player that registers as a Demon to you."
   },
@@ -88,8 +96,10 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 46,
-    "otherNightReminder": "If a player was executed today: Show that player\u2019s character token.",
-    "reminders": ["Executed"],
+    "otherNightReminder": "If a player was executed today: Show that player’s character token.",
+    "reminders": [
+      "Executed"
+    ],
     "setup": false,
     "ability": "Each night*, you learn which character died by execution today."
   },
@@ -102,7 +112,9 @@
     "firstNightReminder": "",
     "otherNight": 10,
     "otherNightReminder": "The previously protected player is no longer protected. The Monk points to a player not themself. Mark that player 'Protected'.",
-    "reminders": ["Protected"],
+    "reminders": [
+      "Protected"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player (not yourself): they are safe from the Demon tonight."
   },
@@ -114,8 +126,8 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 41,
-    "otherNightReminder": "If the Ravenkeeper died tonight: The Ravenkeeper points to a player. Show that player\u2019s character token.",
-    "reminders": [""],
+    "otherNightReminder": "If the Ravenkeeper died tonight: The Ravenkeeper points to a player. Show that player’s character token.",
+    "reminders": [],
     "setup": false,
     "ability": "If you die at night, you are woken to choose a player: you learn their character."
   },
@@ -128,7 +140,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "The 1st time you are nominated, if the nominator is a Townsfolk, they are executed immediately."
   },
@@ -141,7 +155,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, during the day, publicly choose a player: if they are the Demon, they die."
   },
@@ -154,7 +170,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "You are safe from the Demon."
   },
@@ -167,7 +183,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If only 3 players live & no execution occurs, your team wins. If you die at night, another player might die instead."
   },
@@ -180,7 +196,9 @@
     "firstNightReminder": "The Butler points to a player. Mark that player as 'Master'.",
     "otherNight": 45,
     "otherNightReminder": "The Butler points to a player. Mark that player as 'Master'.",
-    "reminders": ["Master"],
+    "reminders": [
+      "Master"
+    ],
     "setup": false,
     "ability": "Each night, choose a player (not yourself): tomorrow, you may only vote if they are voting too."
   },
@@ -194,7 +212,9 @@
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
-    "remindersGlobal": ["Drunk"],
+    "remindersGlobal": [
+      "Drunk"
+    ],
     "setup": true,
     "ability": "You do not know you are the Drunk. You think you are a Townsfolk character, but you are not."
   },
@@ -207,7 +227,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "You might register as evil & as a Minion or Demon, even if dead."
   },
@@ -220,7 +240,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If you are executed, your team loses."
   },
@@ -233,7 +253,9 @@
     "firstNightReminder": "The Poisoner points to a player. That player is poisoned.",
     "otherNight": 5,
     "otherNightReminder": "The previously poisoned player is no longer poisoned. The Poisoner points to a player. That player is poisoned.",
-    "reminders": ["Poisoned"],
+    "reminders": [
+      "Poisoned"
+    ],
     "setup": false,
     "ability": "Each night, choose a player: they are poisoned tonight and tomorrow day"
   },
@@ -246,7 +268,7 @@
     "firstNightReminder": "Show the Grimoire to the Spy for as long as they need.",
     "otherNight": 56,
     "otherNightReminder": "Show the Grimoire to the Spy for as long as they need.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night, you see the Grimoire. You might register as good & as a Townsfolk or Outsider, even if dead."
   },
@@ -259,9 +281,11 @@
     "firstNightReminder": "",
     "otherNight": 15,
     "otherNightReminder": "If the Scarlet Woman became the Demon today: Show the 'You are' card, then the demon token.",
-    "reminders": ["Demon"],
+    "reminders": [
+      "Demon"
+    ],
     "setup": false,
-    "ability": "If there are 5 or more players alive & the Demon dies, you become the Demon. (Travellers don\u2019t count)"
+    "ability": "If there are 5 or more players alive & the Demon dies, you become the Demon. (Travellers don’t count)"
   },
   {
     "id": "baron",
@@ -272,7 +296,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": true,
     "ability": "There are extra Outsiders in play. [+2 Outsiders]"
   },
@@ -285,7 +309,9 @@
     "firstNightReminder": "",
     "otherNight": 19,
     "otherNightReminder": "The Imp points to a player. That player dies. If the Imp chose themselves: Replace the character of 1 alive minion with a spare Imp token. Show the 'You are' card, then the Imp token.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player: they die. If you kill yourself this way, a Minion becomes the Imp."
   },
@@ -298,7 +324,9 @@
     "firstNightReminder": "The Thief points to a player. Put the Thief's 'Negative vote' reminder by the chosen player's character token.",
     "otherNight": 0,
     "otherNightReminder": "The Thief points to a player. Put the Thief's 'Negative vote' reminder by the chosen player's character token.",
-    "reminders": ["Negative vote"],
+    "reminders": [
+      "Negative vote"
+    ],
     "setup": false,
     "ability": "Each night, choose a player (not yourself): their vote counts negatively tomorrow."
   },
@@ -311,7 +339,9 @@
     "firstNightReminder": "The Bureaucrat points to a player. Put the Bureaucrat's '3 votes' reminder by the chosen player's character token.",
     "otherNight": 0,
     "otherNightReminder": "The Bureaucrat points to a player. Put the Bureaucrat's '3 votes' reminder by the chosen player's character token.",
-    "reminders": ["3 votes"],
+    "reminders": [
+      "3 votes"
+    ],
     "setup": false,
     "ability": "Each night, choose a player (not yourself): their vote counts as 3 votes tomorrow."
   },
@@ -324,7 +354,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each day, after the 1st vote has been tallied, you may choose a player that voted: they die."
   },
@@ -337,7 +367,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If a player of your alignment is executed, you might be executed instead."
   },
@@ -350,7 +380,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "You must use a vote token to vote. Dead players may choose to give you theirs. If so, you learn their alignment."
   },
@@ -362,8 +392,10 @@
     "firstNight": 27,
     "firstNightReminder": "Show the marked character token. Point to the marked player.",
     "otherNight": 39,
-    "otherNightReminder": "If the Grandmother\u2019s grandchild was killed by the Demon tonight: The Grandmother dies.",
-    "reminders": ["Grandchild"],
+    "otherNightReminder": "If the Grandmother’s grandchild was killed by the Demon tonight: The Grandmother dies.",
+    "reminders": [
+      "Grandchild"
+    ],
     "setup": false,
     "ability": "You start knowing a good player & character. If the Demon kills them, you die too."
   },
@@ -376,7 +408,9 @@
     "firstNightReminder": "The Sailor points to a living player. Either the Sailor, or the chosen player, is drunk.",
     "otherNight": 2,
     "otherNightReminder": "The previously drunk player is no longer drunk. The Sailor points to a living player. Either the Sailor, or the chosen player, is drunk.",
-    "reminders": ["Drunk"],
+    "reminders": [
+      "Drunk"
+    ],
     "setup": false,
     "ability": "Each night, choose an alive player: either you or they are drunk until dusk. You can't die."
   },
@@ -386,10 +420,10 @@
     "edition": "bmr",
     "team": "townsfolk",
     "firstNight": 37,
-    "firstNightReminder": "The Chambermaid points to two players. Show the number signal (0, 1, 2, \u2026) for how many of those players wake tonight for their ability.",
+    "firstNightReminder": "The Chambermaid points to two players. Show the number signal (0, 1, 2, …) for how many of those players wake tonight for their ability.",
     "otherNight": 59,
-    "otherNightReminder": "The Chambermaid points to two players. Show the number signal (0, 1, 2, \u2026) for how many of those players wake tonight for their ability.",
-    "reminders": [""],
+    "otherNightReminder": "The Chambermaid points to two players. Show the number signal (0, 1, 2, …) for how many of those players wake tonight for their ability.",
+    "reminders": [],
     "setup": false,
     "ability": "Each night, choose 2 alive players (not yourself): you learn how many woke tonight due to their ability."
   },
@@ -400,9 +434,11 @@
     "team": "townsfolk",
     "firstNight": 0,
     "firstNightReminder": "",
-    "otherNight": 17,
+    "otherNight": 18,
     "otherNightReminder": "The Exorcist points to a player, different from the previous night. If that player is the Demon: Wake the Demon. Show the Exorcist token. Point to the Exorcist. The Demon does not act tonight.",
-    "reminders": ["Chosen"],
+    "reminders": [
+      "Chosen"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player (different to last night): the Demon, if chosen, learns who you are then doesn't wake tonight."
   },
@@ -415,8 +451,10 @@
     "firstNightReminder": "",
     "otherNight": 6,
     "otherNightReminder": "The previously protected and drunk players lose those markers. The Innkeeper points to two players. Those players are protected. One is drunk.",
-    "reminders": ["Protected",
-        "Drunk"],
+    "reminders": [
+      "Protected",
+      "Drunk"
+    ],
     "setup": false,
     "ability": "Each night*, choose 2 players: they can't die tonight, but 1 is drunk until dusk."
   },
@@ -429,7 +467,9 @@
     "firstNightReminder": "",
     "otherNight": 8,
     "otherNightReminder": "The Gambler points to a player, and a character on their sheet. If incorrect, the Gambler dies.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player & guess their character: if you guess wrong, you die."
   },
@@ -441,8 +481,10 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 36,
-    "otherNightReminder": "If the Gossip\u2019s public statement was true: Choose a player not protected from dying tonight. That player dies.",
-    "reminders": ["Dead"],
+    "otherNightReminder": "If the Gossip’s public statement was true: Choose a player not protected from dying tonight. That player dies.",
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each day, you may make a public statement. Tonight, if it was true, a player dies."
   },
@@ -455,10 +497,12 @@
     "firstNightReminder": "The Courtier either shows a 'no' head signal, or points to a character on the sheet. If the Courtier used their ability : If that character is in play, that player is drunk.",
     "otherNight": 7,
     "otherNightReminder": "Reduce the remaining number of days the marked player is poisoned. If the Courtier has not yet used their ability: The Courtier either shows a 'no' head signal, or points to a character on the sheet. If the Courtier used their ability: If that character is in play, that player is drunk.",
-    "reminders": ["Drunk 3",
-        "Drunk 2",
-        "Drunk 1",
-        "No ability"],
+    "reminders": [
+      "Drunk 3",
+      "Drunk 2",
+      "Drunk 1",
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, at night, choose a character: they are drunk for 3 nights & 3 days."
   },
@@ -471,8 +515,10 @@
     "firstNightReminder": "",
     "otherNight": 35,
     "otherNightReminder": "If the Professor has not used their ability: The Professor either shakes their head no, or points to a player. If that player is a Townsfolk, they are now alive.",
-    "reminders": ["Alive",
-        "No ability"],
+    "reminders": [
+      "Alive",
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, at night*, choose a dead player: if they are a Townsfolk, they are resurrected."
   },
@@ -485,7 +531,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "Remove the 'Everyone drunk' marker. If a Minion died today: All players but the Minstrel are drunk. Place the 'Everyone drunk' marker.",
-    "reminders": ["Everyone drunk"],
+    "reminders": [
+      "Everyone drunk"
+    ],
     "setup": false,
     "ability": "When a Minion dies by execution, all other players (except Travellers) are drunk until dusk tomorrow."
   },
@@ -498,7 +546,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Can not die"],
+    "reminders": [
+      "Can not die"
+    ],
     "setup": false,
     "ability": "If both your alive neighbours are good, they can't die."
   },
@@ -511,7 +561,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Executed good players might not die."
   },
@@ -524,7 +574,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "The first time you die, you don't."
   },
@@ -537,7 +589,9 @@
     "firstNightReminder": "The Tinker might die.",
     "otherNight": 37,
     "otherNightReminder": "The Tinker might die.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "You might die at any time."
   },
@@ -550,7 +604,9 @@
     "firstNightReminder": "",
     "otherNight": 38,
     "otherNightReminder": "If the Moonchild used their ability to target a player today: If that player is good, they die.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "When you learn that you died, publicly choose 1 alive player. Tonight, if it was a good player, they die."
   },
@@ -560,10 +616,12 @@
     "edition": "bmr",
     "team": "outsider",
     "firstNight": 0,
-    "firstNightReminder": "If a player used their character ability to choose the Goon: The ability does not work. Place the Drunk token on that player. The Goon becomes that player\u2019s alignment. Show 'You are' card. Show thumbs-up good, thumbs-down 'evil' for the Goon\u2019s current alignment.",
+    "firstNightReminder": "If a player used their character ability to choose the Goon: The ability does not work. Place the Drunk token on that player. The Goon becomes that player’s alignment. Show 'You are' card. Show thumbs-up good, thumbs-down 'evil' for the Goon’s current alignment.",
     "otherNight": 0,
-    "otherNightReminder": "If a player used their character ability to choose the Goon: The Goon becomes that player\u2019s alignment. Show the 'You are' card. Show the hand signal (thumbs-up 'good', thumbs-down 'evil') for the Goon\u2019s current alignment.",
-    "reminders": ["Drunk"],
+    "otherNightReminder": "If a player used their character ability to choose the Goon: The Goon becomes that player’s alignment. Show the 'You are' card. Show the hand signal (thumbs-up 'good', thumbs-down 'evil') for the Goon’s current alignment.",
+    "reminders": [
+      "Drunk"
+    ],
     "setup": false,
     "ability": "Each night, the 1st player to choose you with their ability is drunk until dusk. You become their alignment."
   },
@@ -573,12 +631,14 @@
     "edition": "bmr",
     "team": "outsider",
     "firstNight": 3,
-    "firstNightReminder": "If 7 or more players: Show the Lunatic a number of arbitrary 'Minions', players equal to the number of Minions in play. Show 3 character tokens of arbitrary good characters. If the token received by the Lunatic is a Demon that would wake tonight: Allow the Lunatic to do the Demon actions. Place their 'attack' markers. Wake the Demon. Show the Demon\u2019s real character token. Show them the Lunatic player. If the Lunatic attacked players: Show the real demon each marked player. Remove any Lunatic 'attack' markers.",
-    "otherNight": 16,
+    "firstNightReminder": "If 7 or more players: Show the Lunatic a number of arbitrary 'Minions', players equal to the number of Minions in play. Show 3 character tokens of arbitrary good characters. If the token received by the Lunatic is a Demon that would wake tonight: Allow the Lunatic to do the Demon actions. Place their 'attack' markers. Wake the Demon. Show the Demon’s real character token. Show them the Lunatic player. If the Lunatic attacked players: Show the real demon each marked player. Remove any Lunatic 'attack' markers.",
+    "otherNight": 17,
     "otherNightReminder": "Allow the Lunatic to do the actions of the Demon. Place their 'attack' markers. If the Lunatic selected players: Wake the Demon. Show the 'attack' marker, then point to each marked player. Remove any Lunatic 'attack' markers.",
-    "reminders": ["Attack 1",
-        "Attack 2",
-        "Attack 3"],
+    "reminders": [
+      "Attack 1",
+      "Attack 2",
+      "Attack 3"
+    ],
     "setup": false,
     "ability": "You think you are a Demon, but you are not. The Demon knows who you are & who you choose at night."
   },
@@ -591,10 +651,12 @@
     "firstNightReminder": "Show each of the Outsider tokens in play.",
     "otherNight": 31,
     "otherNightReminder": "If an Outsider died today: The Godfather points to a player. That player dies.",
-    "reminders": ["Died today",
-        "Dead"],
+    "reminders": [
+      "Died today",
+      "Dead"
+    ],
     "setup": true,
-    "ability": "You start knowing which Outsiders are in play. If 1 died today, choose a player tonight: they die. [\u22121 or +1 Outsider]"
+    "ability": "You start knowing which Outsiders are in play. If 1 died today, choose a player tonight: they die. [−1 or +1 Outsider]"
   },
   {
     "id": "devilsadvocate",
@@ -602,10 +664,12 @@
     "edition": "bmr",
     "team": "minion",
     "firstNight": 14,
-    "firstNightReminder": "The Devil\u2019s Advocate points to a living player. That player survives execution tomorrow.",
+    "firstNightReminder": "The Devil’s Advocate points to a living player. That player survives execution tomorrow.",
     "otherNight": 11,
-    "otherNightReminder": "The Devil\u2019s Advocate points to a living player, different from the previous night. That player survives execution tomorrow.",
-    "reminders": ["Survives execution"],
+    "otherNightReminder": "The Devil’s Advocate points to a living player, different from the previous night. That player survives execution tomorrow.",
+    "reminders": [
+      "Survives execution"
+    ],
     "setup": false,
     "ability": "Each night, choose a living player (different to last night): if executed tomorrow, they don't die."
   },
@@ -618,8 +682,10 @@
     "firstNightReminder": "",
     "otherNight": 30,
     "otherNightReminder": "If the Assassin has not yet used their ability: The Assassin either shows the 'no' head signal, or points to a player. That player dies.",
-    "reminders": ["Dead",
-        "No ability"],
+    "reminders": [
+      "Dead",
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, at night*, choose a player: they die, even if for some reason they could not."
   },
@@ -632,7 +698,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If the Demon dies by execution (ending the game), play for one more day. If a player is then executed, their team loses."
   },
@@ -645,8 +711,10 @@
     "firstNightReminder": "",
     "otherNight": 20,
     "otherNightReminder": "If no-one died during the day: The Zombuul points to a player. That player dies.",
-    "reminders": ["Died today",
-        "Dead"],
+    "reminders": [
+      "Died today",
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, if no-one died today, choose a player: they die. The 1st time you die, you live but register as dead."
   },
@@ -655,12 +723,14 @@
     "name": "Pukka",
     "edition": "bmr",
     "team": "demon",
-    "firstNight": 18,
+    "firstNight": 19,
     "firstNightReminder": "The Pukka points to a player. That player is poisoned.",
     "otherNight": 21,
     "otherNightReminder": "The poisoned player dies. The Pukka points to a player. That player is poisoned.",
-    "reminders": ["Poisoned",
-        "Dead"],
+    "reminders": [
+      "Poisoned",
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night, choose a player: they are poisoned. The previously poisoned player dies then becomes healthy."
   },
@@ -673,8 +743,10 @@
     "firstNightReminder": "",
     "otherNight": 23,
     "otherNightReminder": "One player that the Shabaloth chose the previous night might be resurrected. The Shabaloth points to two players. Those players die.",
-    "reminders": ["Dead",
-        "Alive"],
+    "reminders": [
+      "Dead",
+      "Alive"
+    ],
     "setup": false,
     "ability": "Each night*, choose 2 players: they die. A dead player you chose last night might be regurgitated."
   },
@@ -687,8 +759,10 @@
     "firstNightReminder": "",
     "otherNight": 24,
     "otherNightReminder": "If the Po chose no-one the previous night: The Po points to three players. Otherwise: The Po either shows the 'no' head signal , or points to a player. Chosen players die",
-    "reminders": ["Dead",
-        "3 attacks"],
+    "reminders": [
+      "Dead",
+      "3 attacks"
+    ],
     "setup": false,
     "ability": "Each night*, you may choose a player: they die. If your last choice was no-one, choose 3 players tonight."
   },
@@ -701,7 +775,9 @@
     "firstNightReminder": "Show the Apprentice the 'You are' card, then a Townsfolk or Minion token. In the Grimoire, replace the Apprentice token with that character token, and put the Apprentice's 'Is the Apprentice' reminder by that character token.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Is the Apprentice"],
+    "reminders": [
+      "Is the Apprentice"
+    ],
     "setup": false,
     "ability": "On your 1st night, you gain a Townsfolk ability (if good), or a Minion ability (if evil)."
   },
@@ -714,7 +790,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each day, you may choose up to 3 pairs of players to swap seats. Players may not leave their seats to talk in private."
   },
@@ -727,7 +803,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, if another player nominated, you may choose to force the current execution to pass or fail."
   },
@@ -740,8 +818,10 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Nominate good",
-        "Nominate evil"],
+    "reminders": [
+      "Nominate good",
+      "Nominate evil"
+    ],
     "setup": false,
     "ability": "Only the Storyteller can nominate. At least 1 opposite player must be nominated each day."
   },
@@ -754,7 +834,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Only you and the dead can vote. They don't need a vote token to do so. A 50% majority is not required."
   },
@@ -767,7 +847,7 @@
     "firstNightReminder": "Show the hand signal for the number (1, 2, 3, etc.) of places from Demon to closest Minion.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "You start knowing how many steps from the Demon to its nearest Minion."
   },
@@ -780,7 +860,7 @@
     "firstNightReminder": "The Dreamer points to a player. Show 1 good and 1 evil character token; one of these is correct.",
     "otherNight": 47,
     "otherNightReminder": "The Dreamer points to a player. Show 1 good and 1 evil character token; one of these is correct.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night, choose a player (not yourself, not Travellers): you learn 1 good and 1 evil character, 1 of which is correct."
   },
@@ -793,7 +873,9 @@
     "firstNightReminder": "The Snake Charmer points to a player. If that player is the Demon: swap the Demon and Snake Charmer character and alignments. Wake each player to inform them of their new role and alignment. The new Snake Charmer is poisoned.",
     "otherNight": 9,
     "otherNightReminder": "The Snake Charmer points to a player. If that player is the Demon: swap the Demon and Snake Charmer character and alignments. Wake each player to inform them of their new role and alignment. The new Snake Charmer is poisoned.",
-    "reminders": ["Poisoned"],
+    "reminders": [
+      "Poisoned"
+    ],
     "setup": false,
     "ability": "Each night, choose an alive player: a chosen Demon swaps characters & alignments with you & is then poisoned."
   },
@@ -806,9 +888,11 @@
     "firstNightReminder": "Show the hand signal for the number (0, 1, 2, etc.) of players whose ability malfunctioned due to other abilities.",
     "otherNight": 58,
     "otherNightReminder": "Show the hand signal for the number (0, 1, 2, etc.) of players whose ability malfunctioned due to other abilities.",
-    "reminders": ["Abnormal"],
+    "reminders": [
+      "Abnormal"
+    ],
     "setup": false,
-    "ability": "Each night, you learn how many players\u2019 abilities worked abnormally (since dawn) due to another character's ability."
+    "ability": "Each night, you learn how many players’ abilities worked abnormally (since dawn) due to another character's ability."
   },
   {
     "id": "flowergirl",
@@ -819,8 +903,10 @@
     "firstNightReminder": "Place the 'Demon not voted' marker.",
     "otherNight": 48,
     "otherNightReminder": "Nod 'yes' or shake head 'no' for whether the Demon voted today. Place the 'Demon not voted' marker (remove 'Demon voted', if any).",
-    "reminders": ["Demon voted",
-        "Demon not voted"],
+    "reminders": [
+      "Demon voted",
+      "Demon not voted"
+    ],
     "setup": false,
     "ability": "Each night*, you learn if a Demon voted today."
   },
@@ -833,8 +919,10 @@
     "firstNightReminder": "Place the 'Minions not nominated' marker.",
     "otherNight": 49,
     "otherNightReminder": "Nod 'yes' or shake head 'no' for whether a Minion nominated today. Place the 'Minion not nominated' marker (remove 'Minion nominated', if any).",
-    "reminders": ["Minions not nominated",
-        "Minion nominated"],
+    "reminders": [
+      "Minions not nominated",
+      "Minion nominated"
+    ],
     "setup": false,
     "ability": "Each night*, you learn if a Minion nominated today"
   },
@@ -847,7 +935,7 @@
     "firstNightReminder": "",
     "otherNight": 50,
     "otherNightReminder": "Show the hand signal for the number (0, 1, 2, etc.) of dead evil players.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night*, you learn how many dead players are evil."
   },
@@ -860,7 +948,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each day, you may visit the Storyteller to learn 2 things in private: 1 is true & 1 is false."
   },
@@ -873,7 +961,9 @@
     "firstNightReminder": "The Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
     "otherNight": 51,
     "otherNightReminder": "If the Seamstress has not yet used their ability: the Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, at night, choose 2 players (not yourself): you learn if they are the same alignment."
   },
@@ -886,8 +976,10 @@
     "firstNightReminder": "The Philosopher either shows a 'no' head signal, or points to a good character on their sheet. If they chose a character: Swap the out-of-play character token with the Philosopher token. Or, if the character is in play, place the drunk marker by that player and the Not the Philosopher token by the Philosopher.",
     "otherNight": 1,
     "otherNightReminder": "If the Philosopher has not used their ability: the Philosopher either shows a 'no' head signal, or points to a good character on their sheet. If they chose a character: Swap the out-of-play character token with the Philosopher token. Or, if the character is in play, place the drunk marker by that player and the Not the Philosopher token by the Philosopher.",
-    "reminders": ["Drunk",
-        "Is not the Philosopher"],
+    "reminders": [
+      "Drunk",
+      "Is not the Philosopher"
+    ],
     "setup": false,
     "ability": "Once per game, at night, choose a good character: gain that ability. If this character is in play, they are drunk."
   },
@@ -900,7 +992,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, during the day, privately ask the Storyteller any yes/no question."
   },
@@ -912,8 +1006,10 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 52,
-    "otherNightReminder": "If today was the Juggler\u2019s first day: Show the hand signal for the number (0, 1, 2, etc.) of 'Correct' markers. Remove markers.",
-    "reminders": ["Correct"],
+    "otherNightReminder": "If today was the Juggler’s first day: Show the hand signal for the number (0, 1, 2, etc.) of 'Correct' markers. Remove markers.",
+    "reminders": [
+      "Correct"
+    ],
     "setup": false,
     "ability": "On your 1st day, publicly guess up to 5 players' characters. That night, you learn how many you got correct."
   },
@@ -926,7 +1022,7 @@
     "firstNightReminder": "",
     "otherNight": 34,
     "otherNightReminder": "If the Sage was killed by a Demon: Point to two players, one of which is that Demon.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If the Demon kills you, you learn that it is 1 of 2 players."
   },
@@ -939,9 +1035,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
-    "ability": "If you are \u201Cmad\u201D about being an Outsider, you might be executed."
+    "ability": "If you are “mad” about being an Outsider, you might be executed."
   },
   {
     "id": "sweetheart",
@@ -952,7 +1048,9 @@
     "firstNightReminder": "",
     "otherNight": 33,
     "otherNightReminder": "Choose a player that is drunk.",
-    "reminders": ["Drunk"],
+    "reminders": [
+      "Drunk"
+    ],
     "setup": false,
     "ability": "When you die, 1 player is drunk from now on."
   },
@@ -965,7 +1063,9 @@
     "firstNightReminder": "",
     "otherNight": 32,
     "otherNightReminder": "If the Barber died today: Wake the Demon. Show the 'This character selected you' card, then Barber token. The Demon either shows a 'no' head signal, or points to 2 players. If they chose players: Swap the character tokens. Wake each player. Show 'You are', then their new character token.",
-    "reminders": ["Haircuts tonight"],
+    "reminders": [
+      "Haircuts tonight"
+    ],
     "setup": false,
     "ability": "If you died today or tonight, the Demon may choose 2 players (not another Demon) to swap characters."
   },
@@ -978,7 +1078,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "When you learn that you died, publicly choose an alive good player or you lose."
   },
@@ -991,7 +1091,9 @@
     "firstNightReminder": "Wake the Evil Twin and their twin. Confirm that they have acknowledged each other. Point to the Evil Twin. Show their Evil Twin token to the twin player. Point to the twin. Show their character token to the Evil Twin player.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Twin"],
+    "reminders": [
+      "Twin"
+    ],
     "setup": false,
     "ability": "You & an opposing player know each other. If the good player is executed, evil wins. Good can't win if you both live."
   },
@@ -1004,7 +1106,9 @@
     "firstNightReminder": "The Witch points to a player. If that player nominates tomorrow they die immediately.",
     "otherNight": 12,
     "otherNightReminder": "If there are 4 or more players alive: The Witch points to a player. If that player nominates tomorrow they die immediately.",
-    "reminders": ["Cursed"],
+    "reminders": [
+      "Cursed"
+    ],
     "setup": false,
     "ability": "Each night, choose a player: if they nominate tomorrow, they die. If just 3 players live, you lose this ability."
   },
@@ -1017,9 +1121,11 @@
     "firstNightReminder": "The Cerenovus points to a player, then to a character on their sheet. Wake that player. Show the 'This character selected you' card, then the Cerenovus token. Show the selected character token. If the player is not mad about being that character tomorrow, they can be executed.",
     "otherNight": 13,
     "otherNightReminder": "The Cerenovus points to a player, then to a character on their sheet. Wake that player. Show the 'This character selected you' card, then the Cerenovus token. Show the selected character token. If the player is not mad about being that character tomorrow, they can be executed.",
-    "reminders": ["Mad"],
+    "reminders": [
+      "Mad"
+    ],
     "setup": false,
-    "ability": "Each night, choose a player & a good character: they are \u201Cmad\u201D they are this character tomorrow, or might be executed."
+    "ability": "Each night, choose a player & a good character: they are “mad” they are this character tomorrow, or might be executed."
   },
   {
     "id": "pithag",
@@ -1030,7 +1136,7 @@
     "firstNightReminder": "",
     "otherNight": 14,
     "otherNightReminder": "The Pit-Hag points to a player and a character on the sheet. If this character is not in play, wake that player and show them the 'You are' card and the relevant character token. If the character is in play, nothing happens.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night*, choose a player & a character they become (if not-in-play). If a Demon is made, deaths tonight are arbitrary."
   },
@@ -1043,7 +1149,9 @@
     "firstNightReminder": "",
     "otherNight": 25,
     "otherNightReminder": "The Fang Gu points to a player. That player dies. Or, if that player was an Outsider and there are no other Fang Gu in play: The Fang Gu dies instead of the chosen player. The chosen player is now an evil Fang Gu. Wake the new Fang Gu. Show the 'You are' card, then the Fang Gu token. Show the 'You are' card, then the thumb-down 'evil' hand sign.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": true,
     "ability": "Each night*, choose a player: they die. The 1st Outsider this kills becomes an evil Fang Gu & you die instead. [+1 Outsider]"
   },
@@ -1056,11 +1164,13 @@
     "firstNightReminder": "",
     "otherNight": 28,
     "otherNightReminder": "The Vigormortis points to a player. That player dies. If a Minion, they keep their ability and one of their Townsfolk neighbours is poisoned.",
-    "reminders": ["Dead",
-        "Has ability",
-        "Poisoned"],
+    "reminders": [
+      "Dead",
+      "Has ability",
+      "Poisoned"
+    ],
     "setup": true,
-    "ability": "Each night*, choose a player: they die. Minions you kill keep their ability & poison 1 Townsfolk neighbour. [\u22121 Outsider]"
+    "ability": "Each night*, choose a player: they die. Minions you kill keep their ability & poison 1 Townsfolk neighbour. [−1 Outsider]"
   },
   {
     "id": "nodashii",
@@ -1071,8 +1181,10 @@
     "firstNightReminder": "",
     "otherNight": 26,
     "otherNightReminder": "The No Dashii points to a player. That player dies.",
-    "reminders": ["Dead",
-        "Poisoned"],
+    "reminders": [
+      "Dead",
+      "Poisoned"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player: they die. Your 2 Townsfolk neighbours are poisoned."
   },
@@ -1085,7 +1197,9 @@
     "firstNightReminder": "",
     "otherNight": 27,
     "otherNightReminder": "The Vortox points to a player. That player dies.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, choose a player; they die. Townsfolk abilities yield false info. Each day, if no-one is executed, evil wins."
   },
@@ -1098,8 +1212,10 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Sober & Healthy",
-        "Ability twice"],
+    "reminders": [
+      "Sober & Healthy",
+      "Ability twice"
+    ],
     "setup": false,
     "ability": "Each night, until dusk, 1) a player becomes sober, healthy and gets true info, or 2) their ability works twice. They learn which."
   },
@@ -1112,7 +1228,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "The Harlot points at any player. Then, put the Harlot to sleep. Wake the chosen player, show them the 'This character selected you' token, then the Harlot token. That player either nods their head yes or shakes their head no. If they nodded their head yes, wake the Harlot and show them the chosen player's character token. Then, you may decide that both players die.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, choose a living player: if they agree, you learn their character, but you both might die."
   },
@@ -1125,7 +1243,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each day, after the 1st execution, you nominate again."
   },
@@ -1138,8 +1256,10 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "The Bone Collector either shakes their head no or points at any dead player. If they pointed at any dead player, put the Bone Collector's 'Has Ability' reminder by the chosen player's character token. (They may need to be woken tonight to use it.)",
-    "reminders": ["No ability",
-        "Has ability"],
+    "reminders": [
+      "No ability",
+      "Has ability"
+    ],
     "setup": false,
     "ability": "Once per game, at night, choose a dead player: they regain their ability until dusk."
   },
@@ -1152,7 +1272,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If you were funny today, you can not be exiled."
   },
@@ -1165,7 +1285,9 @@
     "firstNightReminder": "Point to 1 evil player. Wake the townsfolk who is evil and show them the 'You are' card and the thumbs down evil sign.",
     "otherNight": 54,
     "otherNightReminder": "If the known evil player has died, point to another evil player. ",
-    "reminders": ["Known"],
+    "reminders": [
+      "Known"
+    ],
     "setup": true,
     "ability": "You start knowing 1 evil player. If the player you know dies, you learn another evil player tonight. [1 Townsfolk is evil]"
   },
@@ -1174,12 +1296,14 @@
     "name": "Pixie",
     "edition": "",
     "team": "townsfolk",
-    "firstNight": 19,
+    "firstNight": 18,
     "firstNightReminder": "Show the Pixie 1 in-play Townsfolk role.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Mad",
-        "Has ability"],
+    "reminders": [
+      "Mad",
+      "Has ability"
+    ],
     "setup": false,
     "ability": "You start knowing 1 in-play Townsfolk. If you were mad that you were this character, you gain their ability when they die."
   },
@@ -1192,7 +1316,9 @@
     "firstNightReminder": "The Preacher chooses a player. If a Minion is chosen, wake the Minion and show the 'This character selected you' card and then the Preacher token.",
     "otherNight": 4,
     "otherNightReminder": "The Preacher chooses a player. If a Minion is chosen, wake the Minion and show the 'This character selected you' card and then the Preacher token.",
-    "reminders": ["At a sermon"],
+    "reminders": [
+      "At a sermon"
+    ],
     "setup": false,
     "ability": "Each night, choose a player: a Minion, if chosen, learns this. All chosen Minions have no ability."
   },
@@ -1205,7 +1331,7 @@
     "firstNightReminder": "Show the General thumbs up for good winning, thumbs down for evil winning or thumb to the side for neither.",
     "otherNight": 57,
     "otherNightReminder": "Show the General thumbs up for good winning, thumbs down for evil winning or thumb to the side for neither.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night, you learn which alignment the Storyteller believes is winning: good, evil, or neither."
   },
@@ -1218,11 +1344,13 @@
     "firstNightReminder": "Choose a character type. Point to a player whose character is of that type. Place the Balloonist's Seen reminder next to that character.",
     "otherNight": 53,
     "otherNightReminder": "Choose a character type that does not yet have a Seen reminder next to a character of that type. Point to a player whose character is of that type, if there are any. Place the Balloonist's Seen reminder next to that character.",
-    "reminders": ["Seen Townsfolk",
-        "Seen Outsider",
-        "Seen Minion",
-        "Seen Demon",
-        "Seen Traveller"],
+    "reminders": [
+      "Seen Townsfolk",
+      "Seen Outsider",
+      "Seen Minion",
+      "Seen Demon",
+      "Seen Traveller"
+    ],
     "setup": true,
     "ability": "Each night, you learn 1 player of each character type, until there are no more types to learn. [+1 Outsider]"
   },
@@ -1235,7 +1363,7 @@
     "firstNightReminder": "If the cult leader changed alignment, show them the thumbs up good signal of the thumbs down evil signal accordingly.",
     "otherNight": 55,
     "otherNightReminder": "If the cult leader changed alignment, show them the thumbs up good signal of the thumbs down evil signal accordingly.",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "Each night, you become the alignment of an alive neighbour. If all good players choose to join your cult, your team wins."
   },
@@ -1246,9 +1374,11 @@
     "team": "townsfolk",
     "firstNight": 0,
     "firstNightReminder": "",
-    "otherNight": 18,
+    "otherNight": 16,
     "otherNightReminder": "The Lycanthrope points to a living player: if good, they die and no one else can die tonight.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, choose a living player: if good, they die, but they are the only player that can die tonight."
   },
@@ -1261,7 +1391,9 @@
     "firstNightReminder": "Decide the Amnesiac's entire ability. If the Amnesiac's ability causes them to wake tonight: Wake the Amnesiac and run their ability.",
     "otherNight": 3,
     "otherNightReminder": "If the Amnesiac's ability causes them to wake tonight: Wake the Amnesiac and run their ability.",
-    "reminders": ["?"],
+    "reminders": [
+      "?"
+    ],
     "setup": false,
     "ability": "You do not know what your ability is. Each day, privately guess what it is: you learn how accurate you are."
   },
@@ -1274,7 +1406,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["No ability"],
+    "reminders": [
+      "No ability"
+    ],
     "setup": false,
     "ability": "Once per game, during the day, visit the Storyteller for some advice to help you win."
   },
@@ -1287,8 +1421,10 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "Wake the cannibal when the character who was executed today would wake",
-    "reminders": ["Poisoned",
-        "Died today"],
+    "reminders": [
+      "Poisoned",
+      "Died today"
+    ],
     "setup": false,
     "ability": "You have the ability of the recently killed executee. If they are evil, you are poisoned until a good player dies by execution."
   },
@@ -1301,7 +1437,9 @@
     "firstNightReminder": "If a good living neighbour is drunk or poisoned, the Acrobat player dies.",
     "otherNight": 22,
     "otherNightReminder": "If a good living neighbour is drunk or poisoned, the Acrobat player dies.",
-    "reminders": ["Dead"],
+    "reminders": [
+      "Dead"
+    ],
     "setup": false,
     "ability": "Each night*, if either good living neighbour is drunk or poisoned, you die."
   },
@@ -1314,7 +1452,7 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": [""],
+    "reminders": [],
     "setup": false,
     "ability": "If you were the player most responsible for your team losing, you change alignment & win, even if dead."
   },
@@ -1327,8 +1465,10 @@
     "firstNightReminder": "Show the Grimoire to the Widow for as long as they need. The Widow points to a player. That player is poisoned. Wake a good player. Show the 'These characters are in play' card, then the Widow character token.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Poisoned",
-        "Knows"],
+    "reminders": [
+      "Poisoned",
+      "Knows"
+    ],
     "setup": false,
     "ability": "On your 1st night, look at the Grimoire and choose a player: they are poisoned. 1 good player knows a Widow is in play."
   },
@@ -1341,7 +1481,9 @@
     "firstNightReminder": "",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Claimed"],
+    "reminders": [
+      "Claimed"
+    ],
     "setup": false,
     "ability": "If you publicly claim to be the Goblin when nominated & are executed that day, your team wins."
   },
@@ -1354,9 +1496,10 @@
     "firstNightReminder": "",
     "otherNight": 29,
     "otherNightReminder": "Choose a player, that player dies.",
-    "reminders": [],
-    "remindersGlobal": ["Is the Demon",
-        "Dead"],
+    "reminders": [
+      "Dead",
+      "Is the Demon"
+    ],
     "setup": true,
     "ability": "Each night, Minions choose who babysits Lil Monsta's token & \"is the Demon\". A player dies each night*. [+1 Minion]"
   },
@@ -1369,14 +1512,15 @@
     "firstNightReminder": "Place the Leviathan 'Day 1' marker. Announce 'The Leviathan is in play; this is Day 1.'",
     "otherNight": 0,
     "otherNightReminder": "Place the next Leviathan 'Day n' marker, where 'n' is the next day number. Announce 'The Leviathan is in play; this is Day n.'.",
-    "reminders": ["Day 1",
-        "Day 2",
-        "Day 3",
-        "Day 4",
-        "Day 5",
-        "Good player executed"],
+    "reminders": [
+      "Day 1",
+      "Day 2",
+      "Day 3",
+      "Day 4",
+      "Day 5",
+      "Good player executed"
+    ],
     "setup": false,
     "ability": "If more than 1 good player is executed, you win. All players know you are in play. After day 5, evil wins."
   }
 ]
-


### PR DESCRIPTION
I saw that bunch of empty remainder tokens were added for many roles. I tried to simply edit the firstNight order and add in the pixie character.